### PR TITLE
Explicit semistandard-format dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "happiness-format": "^1.0.0",
     "minimatch": "^2.0.10",
     "pkg-config": "^1.1.0",
-    "semistandard-format": "^1.6.5",
+    "semistandard-format": "1.6.5",
     "standard-format": "^1.6.6"
   }
 }


### PR DESCRIPTION
Issue #16 - being explicit about the semistandard-format dependency version prevents the atom module cache from providing an incompatible version.

Please test - works for me!
