### PR TITLE
fix #49

### DIFF
--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -39,12 +39,14 @@ module.exports = {
   },
 
   activate: function () {
-    this.commands = atom.commands.add('atom-workspace', 'standard-formatter:format', function () {
-      this.setStyle()
-      this.format()
-    }.bind(this))
+    atom.packages.onDidActivateInitialPackages(() => {
+      this.commands = atom.commands.add('atom-workspace', 'standard-formatter:format', function () {
+        this.setStyle()
+        this.format()
+      }.bind(this))
 
-    this.editorObserver = atom.workspace.observeTextEditors(this.handleEvents.bind(this))
+      this.editorObserver = atom.workspace.observeTextEditors(this.handleEvents.bind(this))
+    })
   },
 
   deactivate: function () {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,15 @@
     "standard",
     "formatter"
   ],
-  "activationCommands": [],
+  "activationCommands": {
+    "atom-workspace": "standard-formatter:format"
+  },
+  "activationHooks": [
+    "language-javascript:grammar-used",
+    "language-babel:grammar-used",
+    "language-react:grammar-used",
+    "language-jsx:grammar-used"
+  ],
   "repository": "https://github.com/stephenkubovic/atom-standard-formatter",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
I added all JS grammars I know to the `activationHooks`. Even for unknown grammars the package will still work because of the `activationCommands`, just `onSave` will be broken in that case.

I'm happy to add more grammars if I forgot any.
