### PR TITLE
Support babel-eslint, esprima and esprima-fb custom parsers for standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Don't auto-format files included in the package.json's `"ignore"` configuration 
 
 This package relies on the excellent work from the following modules to perform formatting:
 
-- [standard](https://github.com/feross/standard)
+- [standard](https://github.com/feross/standard), with support for `babel-eslint`, `esprima` and `esprima-fb` custom parsers.
 - [standard-format](https://github.com/maxogden/standard-format)
 - [semistandard-format](https://github.com/ricardofbarros/semistandard-format)
 - [happiness-format](https://github.com/martinheidegger/hapiness-format)

--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -65,7 +65,8 @@ module.exports = {
     var selectedText = selection ? editor.getSelectedText() : null
     var text = selectedText || editor.getText()
     var cursorPosition = editor.getCursorScreenPosition()
-    var transformed = this.transformText(text)
+    var filepath = editor.getPath()
+    var transformed = this.transformText(text, filepath)
 
     if (selectedText) {
       editor.setTextInBufferRange(editor.getSelectedBufferRange(), transformed)
@@ -75,12 +76,12 @@ module.exports = {
     editor.setCursorScreenPosition(cursorPosition)
   },
 
-  transformText: function (text) {
+  transformText: function (text, cwd) {
     var formatter
     if (this.style === 'standard') {
       return allowUnsafeNewFunction(function () {
         try {
-          var res = standardLintTextSync(text, {fix: true})
+          var res = standardLintTextSync(text, {fix: true, cwd: cwd})
           var fixed = res.results[0].output
           return fixed === undefined ? text : fixed
         } catch (e) {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,17 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
+    "babel-eslint": "^7.0.0",
     "deasync": "^0.1.7",
+    "esprima": "^3.1.0",
+    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "find-root": "^0.1.1",
     "happiness-format": "^1.1.0",
     "loophole": "^1.1.0",
     "minimatch": "^2.0.10",
     "pkg-config": "^1.1.0",
     "semistandard-format": "^3.0.0",
-    "standard": "^8.2.0",
+    "standard": "^8.4.0",
     "standard-format": "^2.2.3"
   },
   "devDependencies": {}


### PR DESCRIPTION
Support some popular custom parsers for standard, like `linter-js-standard` does.
