### PR TITLE
Make standard.lintText() synchronous again

### DIFF
--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -5,13 +5,21 @@ var path = require('path')
 var minimatch = require('minimatch')
 var findRoot = require('find-root')
 var allowUnsafeNewFunction = require('loophole').allowUnsafeNewFunction
-var standard = allowUnsafeNewFunction(function () {
-  return require('standard')
-})
 var format = {
   'standard-format': 'standard-format',
   'semi-standard': 'semistandard-format',
   'happiness': 'happiness-format'
+}
+
+function syncLintText (text) {
+  try {
+    opts = this.parseOpts({ fix: true }).eslintConfig
+    var engine = new this.eslint.CLIEngine(opts)
+    return engine.executeOnText(text).results[0].output
+  } catch (err) {
+    console.log('Error transforming using standard:', e)
+    return text
+  }
 }
 
 module.exports = {
@@ -65,39 +73,26 @@ module.exports = {
     var selectedText = selection ? editor.getSelectedText() : null
     var text = selectedText || editor.getText()
     var cursorPosition = editor.getCursorScreenPosition()
-    this.transformText(text, function (e, transformed) {
-      if (e) {
-        console.log('Error transforming using standard:', e)
-        transformed = text
-      }
-      if (selectedText) {
-        editor.setTextInBufferRange(editor.getSelectedBufferRange(), transformed)
-      } else {
-        editor.setText(transformed)
-      }
-      editor.setCursorScreenPosition(cursorPosition)
-    })
+    var transformed = this.transformText(text)
+    if (selectedText) {
+      editor.setTextInBufferRange(editor.getSelectedBufferRange(), transformed)
+    } else {
+      editor.setText(transformed)
+    }
+    editor.setCursorScreenPosition(cursorPosition)
   },
 
-  transformText: function (text, cb) {
-    if (this.style === 'standard') {
-      allowUnsafeNewFunction(function () {
-        require('standard').lintText(text, {fix: true}, function (e, res) {
-          if (e) return cb(e)
-          var fixed = res && Array.isArray(res.results) && res.results[0] && res.results[0].output
-          cb(null, typeof fixed !== 'string' ? text : fixed)
+  transformText: function (text) {
+    try {
+      if (this.style === 'standard') {
+        return allowUnsafeNewFunction(function () {
+          return syncLintText.call(require('standard'), text)
         })
-      })
-    } else if (format.hasOwnProperty(this.style)) {
-      try {
-        cb(null, require(format[this.style]).transform(text))
-      } catch (e) {
-        // Failed to transform, likely due to syntax error in `text`
-        cb(null, text)
+      } else if (format.hasOwnProperty(this.style)) {
+        return require(format[this.style]).transform(text)
       }
-    } else {
-      cb(null, text)
-    }
+    } catch (e) {}
+    return text
   },
 
   setStyle: function () {


### PR DESCRIPTION
Fixes #56. The `standard.lintText()` function is [needlessly asynchronous](https://github.com/Flet/standard-engine/blob/9a25255b308c865ea2ada4598bb2be4f6dac0676/index.js#L58-L70) (note the `nextTick()` function), this simply applies the actual operation in a synchronous way.