### PR TITLE
Support custom parsers for standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Don't auto-format files included in the package.json's `"ignore"` configuration 
 
 This package relies on the excellent work from the following modules to perform formatting:
 
-- [standard](https://github.com/feross/standard)
+- [standard](https://github.com/feross/standard), with support for `babel-eslint`, `esprima` and `esprima-fb` custom parsers.
 - [standard-format](https://github.com/maxogden/standard-format)
 - [semistandard-format](https://github.com/ricardofbarros/semistandard-format)
 - [happiness-format](https://github.com/martinheidegger/hapiness-format)

--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -81,8 +81,13 @@ module.exports = {
 
   transformText: function (text, cb) {
     if (this.style === 'standard') {
+      var parser = this.getPackageConfig().parser
       allowUnsafeNewFunction(function () {
-        require('standard').lintText(text, {fix: true}, function (e, res) {
+        var options = { fix: true }
+        if (parser) {
+          options.parser = parser
+        }
+        require('standard').lintText(text, options, function (e, res) {
           if (e) return cb(e)
           var fixed = res && Array.isArray(res.results) && res.results[0] && res.results[0].output
           cb(null, typeof fixed !== 'string' ? text : fixed)

--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -81,7 +81,7 @@ module.exports = {
 
   transformText: function (text, cb) {
     if (this.style === 'standard') {
-      var parser = this.getPackageConfig().parser
+      var parser = (this.getPackageConfig() || {}).parser
       allowUnsafeNewFunction(function () {
         var options = { fix: true }
         if (parser) {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,16 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
+    "babel-eslint": "^7.1.0",
+    "esprima": "^3.1.1",
+    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "find-root": "^0.1.1",
     "happiness-format": "^1.1.0",
     "loophole": "^1.1.0",
     "minimatch": "^2.0.10",
     "pkg-config": "^1.1.0",
     "semistandard-format": "^3.0.0",
-    "standard": "^8.2.0",
+    "standard": "^8.5.0",
     "standard-format": "^2.2.3"
   },
   "devDependencies": {}


### PR DESCRIPTION
Support some popular custom parsers for standard, includes `babel-eslint`, `esprima` and `esprima-fb`.

This pull request is similar to #51.