### PR TITLE
Add in the `--fix` to `semistandard` linter for better formatting

### DIFF
--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -10,7 +10,7 @@ var standard = allowUnsafeNewFunction(function () {
 })
 var format = {
   'standard-format': 'standard-format',
-  'semi-standard': 'semistandard-format',
+  'semistandard-format': 'semistandard-format',
   'happiness': 'happiness-format'
 }
 
@@ -80,9 +80,13 @@ module.exports = {
   },
 
   transformText: function (text, cb) {
-    if (this.style === 'standard') {
+    if (this.style === 'standard' || this.style === 'semi-standard') {
+      var packageName = {
+        'standard': 'standard',
+        'semi-standard': 'semistandard'
+      }[this.style]
       allowUnsafeNewFunction(function () {
-        require('standard').lintText(text, {fix: true}, function (e, res) {
+        require(packageName).lintText(text, {fix: true}, function (e, res) {
           if (e) return cb(e)
           var fixed = res && Array.isArray(res.results) && res.results[0] && res.results[0].output
           cb(null, typeof fixed !== 'string' ? text : fixed)
@@ -193,7 +197,7 @@ module.exports = {
       default: 'standard',
       title: 'Style Formatter',
       description: 'The module to use for automatically fixing style issues',
-      enum: ['standard', 'standard-format', 'semi-standard', 'happiness']
+      enum: ['standard', 'standard-format', 'semi-standard', 'semistandard-format', 'happiness']
     },
     checkStyleDevDependencies: {
       type: 'boolean',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "loophole": "^1.1.0",
     "minimatch": "^2.0.10",
     "pkg-config": "^1.1.0",
+    "semistandard": "^9.2.1",
     "semistandard-format": "^3.0.0",
     "standard": "^8.2.0",
     "standard-format": "^2.2.3"


### PR DESCRIPTION
- Switch semi-standard over to using the default linter version for formatting
- Updated the old one to semistandard-format in keeping with what was done
with regular standard-formatter