### PR TITLE
add standard-flow Style Formater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # atom-standard-formatter
 
 Atom package to format your Javascript using [Standard Style](https://github.com/feross/standard)
+, [Standard Style with FlowType](https://github.com/Gozala/standard-flow)
 , [Semi-Standard Style](https://github.com/Flet/semistandard)
 or [Happiness Style](https://github.com/jedwatson/happiness).
 
@@ -37,6 +38,7 @@ Check code style in package.json `devDependencies`. If a valid style is not foun
 Choose the style formatter module you want to use. If `checkStyleDevDependencies` is `true` this setting will be ignored.
 
 * [standard](https://github.com/feross/standard) - equivalent to running `standard --fix`
+* [standard-flow](https://github.com/Gozala/standard-flowt)
 * [standard-format](https://github.com/maxogden/standard-format)
 * [semistandard-format](https://github.com/ricardofbarros/semistandard-format)
 * [happiness-format](https://github.com/martinheidegger/hapiness-format)
@@ -52,6 +54,7 @@ Don't auto-format files included in the package.json's `"ignore"` configuration 
 This package relies on the excellent work from the following modules to perform formatting:
 
 - [standard](https://github.com/feross/standard)
+- [standard-flow](https://github.com/Gozala/standard-flow)
 - [standard-format](https://github.com/maxogden/standard-format)
 - [semistandard-format](https://github.com/ricardofbarros/semistandard-format)
 - [happiness-format](https://github.com/martinheidegger/hapiness-format)

--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -9,6 +9,7 @@ var standard = allowUnsafeNewFunction(function () {
   return require('standard')
 })
 var format = {
+  'standard-flow': 'standard-flow',
   'standard-format': 'standard-format',
   'semistandard-format': 'semistandard-format',
   'happiness': 'happiness-format'
@@ -200,7 +201,7 @@ module.exports = {
       default: 'standard',
       title: 'Style Formatter',
       description: 'The module to use for automatically fixing style issues',
-      enum: ['standard', 'standard-format', 'semi-standard', 'semistandard-format', 'happiness']
+      enum: ['standard', 'standard-flow', 'standard-format', 'semi-standard', 'semistandard-format', 'happiness']
     },
     checkStyleDevDependencies: {
       type: 'boolean',

--- a/lib/standard-formatter.js
+++ b/lib/standard-formatter.js
@@ -80,9 +80,10 @@ module.exports = {
   },
 
   transformText: function (text, cb) {
-    if (this.style === 'standard' || this.style === 'semi-standard') {
+    if (this.style === 'standard' || this.style === 'standard-flow' || this.style === 'semi-standard') {
       var packageName = {
         'standard': 'standard',
+        'standard-flow': 'standard-flow',
         'semi-standard': 'semistandard'
       }[this.style]
       allowUnsafeNewFunction(function () {
@@ -127,9 +128,11 @@ module.exports = {
       root: 'devDependencies',
       cache: false
     })
-    if (devDeps && (devDeps.standard || devDeps.semistandard || devDeps.happiness)) {
+    if (devDeps && (devDeps.standard || devDeps.standardflow || devDeps.semistandard || devDeps.happiness)) {
       if (devDeps.standard) {
         style = 'standard'
+      } else if (devDeps.standardflow) {
+        style = 'standard-flow'
       } else if (devDeps.semistandard) {
         style = 'semi-standard'
       } else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "standard-formatter",
   "main": "./lib/standard-formatter.js",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Format file contents using JavaScript Standard Style",
   "keywords": [
     "javascript",
@@ -15,15 +15,16 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "find-root": "^0.1.1",
+    "find-root": "^1.0.0",
     "happiness-format": "^1.1.0",
     "loophole": "^1.1.0",
-    "minimatch": "^2.0.10",
-    "pkg-config": "^1.1.0",
-    "semistandard": "^9.2.1",
+    "minimatch": "^3.0.3",
+    "pkg-config": "^1.1.1",
+    "semistandard": "^10.0.0",
     "semistandard-format": "^3.0.0",
-    "standard": "^8.2.0",
-    "standard-format": "^2.2.3"
+    "standard": "^10.0.2",
+    "standard-flow": "^1.0.0",
+    "standard-format": "^2.2.4"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
It works by settings inside package.json: `devDependencies": { "standardflow": "*"}` with enabled `Honor Package Config` or by selecting Style Formater to `standard-flow`. The parser understands [FlowType](https://flow.org/) syntax.
